### PR TITLE
Fix considering history back without closing popup

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -12,3 +12,19 @@ chrome.tabs.onActivated.addListener((activeInfo) => {
     message
   )
 })
+
+chrome.tabs.onUpdated.addListener((_tabId, _changeInfo, tab) => {
+  if (tab.status === 'complete') {
+    chrome.tabs.executeScript({
+      file: 'contentScript.js'
+    })
+    const message: ClearResult = {
+      type: MessageType.ClearResult,
+      payload: undefined
+    }
+    tab.id && chrome.tabs.sendMessage(
+      tab.id,
+      message
+    )
+  }
+})

--- a/src/core/page-searcher.ts
+++ b/src/core/page-searcher.ts
@@ -46,9 +46,21 @@ function createHighlightGroup(highlightGroupDOM: HTMLElement): HighlightGroup {
     const newNode = document.createTextNode(highlightGroupDOM.textContent || '')
     highlightGroupDOM.parentNode?.replaceChild(newNode, highlightGroupDOM)
   }
+  highlightGroupDOM.setAttribute(HighlightGroup.HIGHLIGHT_GROUP_DOM_ATTRIBUTE, HighlightGroup.HIGHLIGHT_GROUP_DOM_ATTRIBUTE)
 
   return {
     clear
+  }
+}
+namespace HighlightGroup {
+  export const HIGHLIGHT_GROUP_DOM_ATTRIBUTE = 'data-highlight-group'
+
+  // Clear HighlightGroups whenever elements refreshed.
+  export function clearAll() {
+    document.querySelectorAll<HTMLElement>(`[${HIGHLIGHT_GROUP_DOM_ATTRIBUTE}=${HIGHLIGHT_GROUP_DOM_ATTRIBUTE}]`).forEach((dom) => {
+      const highlightGroup = createHighlightGroup(dom)
+      highlightGroup.clear()
+    })
   }
 }
 
@@ -184,10 +196,8 @@ export function createPageSearcher(rootDOM: HTMLElement): PageSearcher {
   let changeHighlightListener: PageSearcher.ChangeHighlightListener | null = null
   const store = createStore<HighlightGroup, Highlight>()
 
-  store.onClear((highlightGroups) => {
-    highlightGroups.forEach((hg) => {
-      hg.clear()
-    })
+  store.onClear((_highlightGroups) => {
+    HighlightGroup.clearAll()
   })
 
   store.onChangeHighlightSelection(({

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -154,6 +154,12 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   return true
 })
 
+chrome.tabs.onUpdated.addListener((_tabId, _changeInfo, tab) => {
+  if (tab.status === 'complete') {
+    previousQuery = ''
+  }
+})
+
 chrome.tabs.executeScript({
   file: 'contentScript.js'
 })


### PR DESCRIPTION
Fix considering history back without closing popup (e.g. history back by shortcut)

When history back without closing popup: 
* clear results
* enable to search
* clear previous query